### PR TITLE
Fixed wrong logo render in safari

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -35,6 +35,11 @@
 .logo-svg-text {
   fill: var(--ifm-color-primary)
 }
+
+.logo-svg-text tspan {
+  white-space: pre
+}
+
 .navbar__logo img {
   fill: var(--ifm-color-primary)
 }


### PR DESCRIPTION
Hello! Thanks for great plugin manager.
I note what logo no correct render on Safari, because you use `xml:space="preserve"` but it's [deprecated](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xml:space).

Before (on Safari):
<img width="841" alt="lazy-safari" src="https://user-images.githubusercontent.com/46977173/213755320-340cedd7-ff65-46e6-b22e-5800ac3f2383.png">

After: 
<img width="983" alt="lazy-safari-after" src="https://user-images.githubusercontent.com/46977173/213755615-bd3c98d6-b390-4454-943d-bb4284aeca44.png">

I also checked it with Mozilla and Chrome after patch – works same

