### PR TITLE
Added -Force to removing the .git folder

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -72,7 +72,7 @@ with [PowerShell](https://github.com/PowerShell/PowerShell)
 - Remove the `.git` folder, so you can add it to your own repo later
 
   ```powershell
-  Remove-Item $env:LOCALAPPDATA\nvim\.git -Recurse
+  Remove-Item $env:LOCALAPPDATA\nvim\.git -Recurse -Force
   ```
 
 - Start Neovim!


### PR DESCRIPTION
Because .git is a hidden folder, `Remove-Item` does not let you remove it without `-Force` 
tldrify.com/1ad2