### PR TITLE
Add mini.pairs section to keymaps.md

### DIFF
--- a/docs/keymaps.md
+++ b/docs/keymaps.md
@@ -131,6 +131,12 @@ possible keymaps starting with `<space>`.
 | <code>&lt;leader&gt;bd</code> | Delete Buffer | **n** |
 | <code>&lt;leader&gt;bD</code> | Delete Buffer (Force) | **n** |
 
+## [mini.pairs](https://github.com/echasnovski/mini.pairs.git)
+
+| Key | Description | Mode |
+| --- | --- | --- |
+| <code>&lt;C-v&gt;</code> | Insert single character of a pair | **i** |
+
 ## [mini.surround](https://github.com/echasnovski/mini.surround.git)
 
 | Key | Description | Mode |


### PR DESCRIPTION
This has been by far most painful part of adapting lazyvim, not bing able to write singles and ending up typing first double, moving cursor to end of pair, removing closing pair, moving the end of the word and do the same. 

had also to dig quite [deep](https://github.com/echasnovski/mini.nvim/blob/main/doc/mini-pairs.txt) to find solution for it, so would appreciate to have it in lazyvim docs too.