### PR TITLE
chore: update examples.md to fix typo

### DIFF
--- a/docs/configuration/examples.md
+++ b/docs/configuration/examples.md
@@ -79,7 +79,7 @@ return {
 
   -- add telescope-fzf-native
   {
-    "telescope.nvim",
+    "nvim-telescope/telescope.nvim",
     dependencies = {
       "nvim-telescope/telescope-fzf-native.nvim",
       build = "make",


### PR DESCRIPTION
I think you need to provide the full plugin name, not the short one