### PR TITLE
fix: avoid telescope-fzf-native error message on first install

### DIFF
--- a/docs/configuration/examples.md
+++ b/docs/configuration/examples.md
@@ -79,14 +79,14 @@ return {
 
   -- add telescope-fzf-native
   {
-    "telescope.nvim",
+    "nvim-telescope/telescope.nvim",
     dependencies = {
       "nvim-telescope/telescope-fzf-native.nvim",
       build = "make",
-      config = function()
-        require("telescope").load_extension("fzf")
-      end,
     },
+    config = function()
+      require("telescope").load_extension("fzf")
+    end,
   },
 
   -- add pyright to lspconfig

--- a/docs/configuration/recipes.md
+++ b/docs/configuration/recipes.md
@@ -26,14 +26,14 @@ override nvim-cmp and add cmp-emoji
 
 ```lua
 {
-  "telescope.nvim",
+  "nvim-telescope/telescope.nvim",
   dependencies = {
     "nvim-telescope/telescope-fzf-native.nvim",
     build = "make",
-    config = function()
-      require("telescope").load_extension("fzf")
-    end,
   },
+  config = function()
+    require("telescope").load_extension("fzf")
+  end,
 }
 ```
 

--- a/lua/recipes.lua
+++ b/lua/recipes.lua
@@ -14,14 +14,14 @@ return {
 
   -- ## Add telescope-fzf-native
   {
-    "telescope.nvim",
+    "nvim-telescope/telescope.nvim",
     dependencies = {
       "nvim-telescope/telescope-fzf-native.nvim",
       build = "make",
-      config = function()
-        require("telescope").load_extension("fzf")
-      end,
     },
+    config = function()
+      require("telescope").load_extension("fzf")
+    end,
   },
 
   -- ## Supertab


### PR DESCRIPTION
Clean environment:
```bash
rm -rf ~/.local/share/nvim ~/.local/state/nvim ~/.cache/nvim
```

Configuration with problem
```lua
❯ cat ~/.config/nvim/lua/plugins/telescope.lua
return {
  {
    "telescope.nvim",
    dependencies = {
      "nvim-telescope/telescope-fzf-native.nvim",
      build = "make",
      config = function()
        require("telescope").load_extension("fzf")
      end,
    },
  },
}
```

Install all plugins:
```
nvim --headless "+Lazy! sync" +qa
```

Error message:
```
Error detected while processing /home/robson.peixoto/.config/nvim/init.lua:
Failed to run `config` for telescope-fzf-native.nvim
/home/robson.peixoto/.config/nvim/lua/plugins/telescope.lua:8: module 'telescope' not found:
^Ino field package.preload['telescope']
cache_loader: module telescope not found
cache_loader_lib: module telescope not found
^Ino file './telescope.lua'
^Ino file '/home/linuxbrew/.linuxbrew/share/luajit-2.1.0-beta3/telescope.lua'
^Ino file '/usr/local/share/lua/5.1/telescope.lua'
^Ino file '/usr/local/share/lua/5.1/telescope/init.lua'
^Ino file '/home/linuxbrew/.linuxbrew/share/lua/5.1/telescope.lua'
^Ino file '/home/linuxbrew/.linuxbrew/share/lua/5.1/telescope/init.lua'
^Ino file './telescope.so'
^Ino file '/usr/local/lib/lua/5.1/telescope.so'
^Ino file '/home/linuxbrew/.linuxbrew/lib/lua/5.1/telescope.so'
^Ino file '/usr/local/lib/lua/5.1/loadall.so'
# stacktrace:
  - .config/nvim/lua/plugins/telescope.lua:8 _in_ **config**
  - .config/nvim/lua/config/lazy.lua:9
  - .config/nvim/init.lua:2%                                                                                                                                              
```
