### PR TITLE
Update recipes.md to add recipe for icon fix when using a v3 Nerd Font

### DIFF
--- a/docs/configuration/recipes.md
+++ b/docs/configuration/recipes.md
@@ -190,4 +190,46 @@ Important: make sure not to add prettier to null-ls, otherwise this won't work!
 }
 ```
 
+## Fix broken icons in Neo-Tree when using a v3 Nerd Font
+
+```lua
+{
+  "nvim-neo-tree/neo-tree.nvim",
+  opts = {
+    default_component_configs = {
+      icon = {
+        folder_empty = "󰜌",
+        folder_empty_open = "󰜌",
+      },
+      git_status = {
+        symbols = {
+          renamed = "󰁕",
+          unstaged = "󰄱",
+        },
+      },
+    },
+    document_symbols = {
+      kinds = {
+        File = { icon = "󰈙", hl = "Tag" },
+        Namespace = { icon = "󰌗", hl = "Include" },
+        Package = { icon = "󰏖", hl = "Label" },
+        Class = { icon = "󰌗", hl = "Include" },
+        Property = { icon = "󰆧", hl = "@property" },
+        Enum = { icon = "󰒻", hl = "@number" },
+        Function = { icon = "󰊕", hl = "Function" },
+        String = { icon = "󰀬", hl = "String" },
+        Number = { icon = "󰎠", hl = "Number" },
+        Array = { icon = "󰅪", hl = "Type" },
+        Object = { icon = "󰅩", hl = "Type" },
+        Key = { icon = "󰌋", hl = "" },
+        Struct = { icon = "󰌗", hl = "Type" },
+        Operator = { icon = "󰆕", hl = "Operator" },
+        TypeParameter = { icon = "󰊄", hl = "Type" },
+        StaticMethod = { icon = "󰠄 ", hl = "Function" },
+      },
+    },
+  },
+}
+```
+
 <!-- recipes:end -->


### PR DESCRIPTION
Issue 957 - Underlying issue in Neo-Tree v2 with some icons broken by Nerd Font v3.0 (but these are what's available to download from https://github.com/ryanoasis/nerd-fonts). Someone doing a fresh install of a Nerd Font and a fresh LazyVim install will get some broken icons right now.