### PR TITLE
Update recipes.md to show how to get VS Code autocompletion behavior for tab

### DIFF
--- a/docs/configuration/recipes.md
+++ b/docs/configuration/recipes.md
@@ -74,6 +74,7 @@ Use `<tab>` for completion and snippets (supertab).
     opts.mapping = vim.tbl_extend("force", opts.mapping, {
       ["<Tab>"] = cmp.mapping(function(fallback)
         if cmp.visible() then
+        -- You could replace select_next_item() with confirm({ select = true }) to get VS Code autocompletion behavior
           cmp.select_next_item()
         -- You could replace the expand_or_jumpable() calls with expand_or_locally_jumpable()
         -- this way you will only jump inside the snippet region


### PR DESCRIPTION
The recipe shows how to get Tab / Shift-Tab to cycle through autocompletion suggestions, but Enter has to be pressed to select the first suggestion (when it's partially typed in). In VS Code, Tab behaves like Enter does in the default config here.