### PR TITLE
fix: import order of `clangd`

### DIFF
--- a/docs/plugins/extras/lang.clangd.md
+++ b/docs/plugins/extras/lang.clangd.md
@@ -8,8 +8,8 @@ To use this, add it to your **lazy.nvim** imports:
 require("lazy").setup({
   spec = {
     { "LazyVim/LazyVim", import = "lazyvim.plugins" },
-    { import = "lazyvim.plugins.extras.lang.clangd" },
     { import = "plugins" },
+    { import = "lazyvim.plugins.extras.lang.clangd" },
   },
 })
 ```


### PR DESCRIPTION
Since https://github.com/LazyVim/LazyVim/blob/fb1f29c32c516601b4074d113202482769ef030e/lua/lazyvim/plugins/extras/lang/clangd.lua#L109 checks if `ensure_installed` is a table, importing `clangd` before `plugins` won't add `codelldb` to the list at all