### PR TITLE
docs: change how the recipes disables tsserver formatting

### DIFF
--- a/docs/configuration/recipes.md
+++ b/docs/configuration/recipes.md
@@ -175,14 +175,12 @@ Important: make sure not to add prettier to null-ls, otherwise this won't work!
 {
   "neovim/nvim-lspconfig",
   opts = {
-    servers = { eslint = {} },
+    servers = { tsserver = { disable_formatting = true } },
     setup = {
       eslint = function()
         require("lazyvim.util").on_attach(function(client)
           if client.name == "eslint" then
             client.server_capabilities.documentFormattingProvider = true
-          elseif client.name == "tsserver" then
-            client.server_capabilities.documentFormattingProvider = false
           end
         end)
       end,


### PR DESCRIPTION
I noticed that the `tsserver` formatting is disabled by overriding the server's capabilities. This is fine and works, but maybe a nicer way to do it would be by using the `tsserver` option that disables formatting instead.