### PR TITLE
docs: document default plugins

### DIFF
--- a/docs/plugins/_category_.yml
+++ b/docs/plugins/_category_.yml
@@ -1,5 +1,2 @@
 label: 📦 Plugins
 position: 6
-link:
-  type: doc
-  id: configuration/plugins

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -1,0 +1,14 @@
+# Included Plugins
+
+**LazyNvim** comes with some preconfigured plugins that are enabled by default. You don't need to do anything to set these up besides installing LazyNvim starter template. These are broken up into the following lua configuration files:
+
+- [Coding](./coding.md) - configures plugins that help general coding. E.g. snippets, autocompletion, language server protocol, etc.
+- [Colorscheme](./colorscheme.md) - adds some default color schemes (tokyonight and catppuccin).
+- [Editor](./editor.md) - adds plugins that configure file explore, global search and replace, fuzzy finding, key binding seach, git integration, and highlighting.
+- [LSP](./lsp.md) - configures the Language Server Protocol tools and formatters.
+- [TreeSitter](./treesitter.md) - configures plugins for syntax highlighting.
+- [UI](./ui.md) - configures plugins that affect the way that the nvim UI works. E.g. status lines, tabs, indentation lines, icons, and other UI components.
+- [Util](./util.md) - some util plugins for measuring startup time, handling session persistance, and general shared functionality
+
+See each of the above docs for information on the defaults for each set of plugins and how to override the options.
+


### PR DESCRIPTION
There are two concepts that are both referred to as plugins in LazyNvim,
the user's plugins as well as the included plugins. This document aims
to help clarify the ambiguity.
