### PR TITLE
fix: Fixed the Next link on the Tips page

### DIFF
--- a/docs/plugins/_category_.yml
+++ b/docs/plugins/_category_.yml
@@ -1,5 +1,2 @@
 label: 📦 Plugins
 position: 6
-link:
-  type: doc
-  id: configuration/plugins


### PR DESCRIPTION
Currently, the `Next` link on the [Configuration / Tips page](https://www.lazyvim.org/configuration/tips) leads to the `Configuration / Plugins` page instead `Plugins / Coding`. This PR corrects this behavior