### PR TITLE
Update gitsigns wording.md

### DIFF
--- a/docs/plugins/editor.md
+++ b/docs/plugins/editor.md
@@ -555,7 +555,7 @@ opts = {
 
 ## [gitsigns.nvim](https://github.com/lewis6991/gitsigns.nvim)
 
- git signs highlights text that has changed since the list
+ git signs highlights text that has changed since the last
  git commit, and also lets you interactively stage & unstage
  hunks in a commit.
 


### PR DESCRIPTION
Changed:

"git signs highlights text that has changed since the list git commit"

to 

"git signs highlights text that has changed since the last git commit"