### PR TITLE
Update eslint recipes

### DIFF
--- a/lua/recipes.lua
+++ b/lua/recipes.lua
@@ -144,7 +144,7 @@ return {
       servers = { eslint = {} },
       setup = {
         eslint = function()
-          require("lazyvim.util").on_attach(function(client)
+          require("lazyvim.util").lsp.on_attach(function(client)
             if client.name == "eslint" then
               client.server_capabilities.documentFormattingProvider = true
             elseif client.name == "tsserver" then


### PR DESCRIPTION
The recipe is using the deprecated `require("lazyvim.util").on_attach`. This PR updates the recipe to the suggested use of `require("lazyvim.util").lsp.on_attach`

<img width="1233" alt="Screenshot 2023-10-12 at 2 12 15 PM" src="https://github.com/LazyVim/lazyvim.github.io/assets/3885959/4bf99f3e-26f2-4aa4-8add-c01f34c9b3c9">
