### PR TITLE
Update keymaps.md

### DIFF
--- a/docs/keymaps.md
+++ b/docs/keymaps.md
@@ -159,13 +159,13 @@ possible keymaps starting with `<space>`.
 
 | Key | Description | Mode |
 | --- | --- | --- |
-| <code>gsa</code> | Add surrounding | **n**, **v** |
-| <code>gsd</code> | Delete surrounding | **n** |
-| <code>gsf</code> | Find right surrounding | **n** |
-| <code>gsF</code> | Find left surrounding | **n** |
-| <code>gsh</code> | Highlight surrounding | **n** |
-| <code>gsn</code> | Update `MiniSurround.config.n_lines` | **n** |
-| <code>gsr</code> | Replace surrounding | **n** |
+| <code>gza</code> | Add surrounding | **n**, **v** |
+| <code>gzd</code> | Delete surrounding | **n** |
+| <code>gzf</code> | Find right surrounding | **n** |
+| <code>gzF</code> | Find left surrounding | **n** |
+| <code>gzh</code> | Highlight surrounding | **n** |
+| <code>gzn</code> | Update `MiniSurround.config.n_lines` | **n** |
+| <code>gzr</code> | Replace surrounding | **n** |
 
 ## [neo-tree.nvim](https://github.com/nvim-neo-tree/neo-tree.nvim.git)
 


### PR DESCRIPTION
LazyVim 10.14.6 uses `gz` instead of `gs` for **mini.surround**.