### PR TITLE
Fixing Dead nvim.mason link

### DIFF
--- a/docs/extras/lang/cmake.md
+++ b/docs/extras/lang/cmake.md
@@ -66,7 +66,7 @@ end
 
 </Tabs>
 
-## [mason.nvim](https://github.com/mason.nvim)
+## [mason.nvim](https://github.com/williamboman/mason.nvim)
 
 <Tabs>
 


### PR DESCRIPTION
It's missing part of the route, and gives a 406 when you click it.