### PR TITLE
rm cmp-emoji dep from supertab recipe

### DIFF
--- a/docs/configuration/examples.md
+++ b/docs/configuration/examples.md
@@ -227,9 +227,6 @@ return {
   -- then: setup supertab in cmp
   {
     "hrsh7th/nvim-cmp",
-    dependencies = {
-      "hrsh7th/cmp-emoji",
-    },
     ---@param opts cmp.ConfigSchema
     opts = function(_, opts)
       local has_words_before = function()

--- a/docs/configuration/recipes.md
+++ b/docs/configuration/recipes.md
@@ -57,9 +57,6 @@ Use `<tab>` for completion and snippets (supertab).
 ```lua
 {
   "hrsh7th/nvim-cmp",
-  dependencies = {
-    "hrsh7th/cmp-emoji",
-  },
   ---@param opts cmp.ConfigSchema
   opts = function(_, opts)
     local has_words_before = function()

--- a/lua/recipes.lua
+++ b/lua/recipes.lua
@@ -38,9 +38,6 @@ return {
   -- 2. Setup supertab in cmp
   {
     "hrsh7th/nvim-cmp",
-    dependencies = {
-      "hrsh7th/cmp-emoji",
-    },
     ---@param opts cmp.ConfigSchema
     opts = function(_, opts)
       local has_words_before = function()


### PR DESCRIPTION
I believe there's a typo in the docs -- the cmp-emoji dependency should not be necessary for the supertab recipe. This was probably copied-and-pasted from another part of the docs (the recipe for adding cmp-emoji).