### PR TITLE
docs: remove duplicates of dressing.nvim

### DIFF
--- a/docs/plugins/ui.md
+++ b/docs/plugins/ui.md
@@ -114,52 +114,6 @@ opts = nil
 
 </Tabs>
 
-## [dressing.nvim](https://github.com/dressing.nvim)
-
-<Tabs>
-
-<TabItem value="opts" label="Options">
-
-```lua
-opts = nil
-```
-
-</TabItem>
-
-
-<TabItem value="code" label="Full Spec">
-
-```lua
-{ "dressing.nvim" }
-```
-
-</TabItem>
-
-</Tabs>
-
-## [dressing.nvim](https://github.com/dressing.nvim)
-
-<Tabs>
-
-<TabItem value="opts" label="Options">
-
-```lua
-opts = nil
-```
-
-</TabItem>
-
-
-<TabItem value="code" label="Full Spec">
-
-```lua
-{ "dressing.nvim" }
-```
-
-</TabItem>
-
-</Tabs>
-
 ## [bufferline.nvim](https://github.com/akinsho/bufferline.nvim)
 
  This is what powers LazyVim's fancy-looking


### PR DESCRIPTION
## Description

This PR will remove duplicates of the `dressing.nvim` package from the `/plugin/ui.md` file.  The links of the duplicates also did not work, so I guess this was not intentional.