### PR TITLE
doc: fix a grammar error on `configuration/general` route of the official website

### DIFF
--- a/docs/configuration/general.md
+++ b/docs/configuration/general.md
@@ -25,7 +25,7 @@ so you don't need to require those files manually.
 ```
 
 :::danger
-Do not `require` `autocmds`, `keymaps`, `lazy` or `options` under `lua/config/` or `lazyvim.config` manually.
+Do not put `require` `autocmds`, `keymaps`, `lazy` or `options` files under `lua/config/` or `lazyvim.config` manually.
 **LazyVim** will load those files automatically.
 :::
 


### PR DESCRIPTION
I fixed a grammar error on the `danger` section of [this page](https://www.lazyvim.org/configuration/general).