### PR TITLE
remove duplicate nvim-lspconfig section

### DIFF
--- a/docs/plugins/lsp.md
+++ b/docs/plugins/lsp.md
@@ -349,29 +349,6 @@ opts = {}
 
 </Tabs>
 
-## [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig)
-
-<Tabs>
-
-<TabItem value="opts" label="Options">
-
-```lua
-opts = nil
-```
-
-</TabItem>
-
-
-<TabItem value="code" label="Full Spec">
-
-```lua
-{ "nvim-lspconfig" }
-```
-
-</TabItem>
-
-</Tabs>
-
 ## [neodev.nvim](https://github.com/folke/neodev.nvim)
 
 <Tabs>


### PR DESCRIPTION
the first section seems like it has the actual info, and the second section, the one i'm deleting, is empty.