### PR TITLE
fix(lazyrc): Fix `lazyrc` docs

### DIFF
--- a/docs/extras/lazyrc.md
+++ b/docs/extras/lazyrc.md
@@ -2,20 +2,21 @@
 
 <!-- plugins:start -->
 
-:::info
-You can enable the extra with the `:LazyExtras` command.
-Plugins marked as optional will only be configured if they are installed.
+:::caution
+You should not enable this Extra from `:LazyExtras`
 :::
 
 <details>
-<summary>Alternatively, you can add it to your <code>lazy.nvim</code> imports</summary>
+<summary>You should add it to your <code>lazy.nvim</code> imports as the last import.
+  This is a special case for this Extra and this should be the only one added as the
+  very last import after your <code>import = "plugins"</code></summary>
 
 ```lua title="lua/config/lazy.lua" {4}
 require("lazy").setup({
   spec = {
     { "LazyVim/LazyVim", import = "lazyvim.plugins" },
-    { import = "lazyvim.plugins.extras.lazyrc" },
     { import = "plugins" },
+    { import = "lazyvim.plugins.extras.lazyrc" },
   },
 })
 ```


### PR DESCRIPTION
Fix the docs of `lazyrc` to be in sync with how https://github.com/LazyVim/LazyVim/pull/2115 suggests to import the Extra