### PR TITLE
chore(docs-colorscheme): clarify loading colorscheme into LazyVim with Catppuccin example

### DIFF
--- a/docs/plugins/colorscheme.md
+++ b/docs/plugins/colorscheme.md
@@ -156,7 +156,6 @@ opts = {
       colorscheme = "catppuccin",
     },
   },
-
 }
 ```
 

--- a/docs/plugins/colorscheme.md
+++ b/docs/plugins/colorscheme.md
@@ -148,6 +148,15 @@ opts = {
       which_key = true,
     },
   },
+
+-- Configure LazyVim to load the above settings
+  {
+    "LazyVim/LazyVim",
+    opts = {
+      colorscheme = "catppuccin",
+    },
+  },
+
 }
 ```
 


### PR DESCRIPTION
Show loading the Catppuccin colorscheme explicitly.