### PR TITLE
Update `editUrl` in docusaurus.config.js

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -36,7 +36,7 @@ const config = {
         docs: {
           routeBasePath: "/",
           sidebarPath: require.resolve("./sidebars.js"),
-          editUrl: "https://github.com/LazyVim/lazyvim.github.io/tree/master/",
+          editUrl: "https://github.com/LazyVim/lazyvim.github.io/tree/main/",
         },
         blog: false,
         theme: {


### PR DESCRIPTION
When jumping to  `Edit this page`, it shows `Branch not found, redirected to default branch` message. This renames the branch from `master` to `main`.