### PR TITLE
fix(fzf): replace lazy.nvim imports by warning about it

### DIFF
--- a/docs/extras/editor/fzf.md
+++ b/docs/extras/editor/fzf.md
@@ -7,20 +7,9 @@ You can enable the extra with the `:LazyExtras` command.
 Plugins marked as optional will only be configured if they are installed.
 :::
 
-<details>
-<summary>Alternatively, you can add it to your <code>lazy.nvim</code> imports</summary>
-
-```lua title="lua/config/lazy.lua" {4}
-require("lazy").setup({
-  spec = {
-    { "LazyVim/LazyVim", import = "lazyvim.plugins" },
-    { import = "lazyvim.plugins.extras.editor.fzf" },
-    { import = "plugins" },
-  },
-})
-```
-
-</details>
+:::caution
+this extra can't be enabled by adding it to your `lazy.nvim` imports, use `:LazyExtras` instead.
+:::
 
 Below you can find a list of included plugins and their default settings.
 


### PR DESCRIPTION
see https://github.com/LazyVim/LazyVim/issues/3626 for why fzf can't be enabled this way.

also, i guess it's because it's auto generated, but the page for fzf https://www.lazyvim.org/extras/editor/fzf is missing all the config.
there is the
> Below you can find a list of included plugins and their default settings.

but list of included plugins and their default settings is not shown.

thanks !