### PR TITLE
fix: rename Omnisharp to C#

### DIFF
--- a/docs/extras/lang/csharp.md
+++ b/docs/extras/lang/csharp.md
@@ -1,4 +1,8 @@
-# OmniSharp
+---
+title: C#
+---
+
+# C#
 
 <!-- plugins:start -->
 


### PR DESCRIPTION
The "lang" section of the Extras should list languages, not names of tools that provide support for a given language.
Users who are searching for C# will probably look for exactly that, and not "Omnisharp", which is an LSP for C#. Users might not even know what Omnisharp is.