### PR TITLE
fix(recipes.md): disable vtsls format for eslint

### DIFF
--- a/docs/configuration/recipes.md
+++ b/docs/configuration/recipes.md
@@ -152,6 +152,8 @@ Important: make sure not to add prettier to null-ls, otherwise this won't work!
             client.server_capabilities.documentFormattingProvider = true
           elseif client.name == "tsserver" then
             client.server_capabilities.documentFormattingProvider = false
+          elseif client.name == "vtsls" then
+            client.server_capabilities.documentFormattingProvider = false
           end
         end)
       end,


### PR DESCRIPTION
Due to change of default LSP for typescript to `vtsls`, we need to disable it's formatting too