### PR TITLE
Docs: CopilotChat.nvim - Undefined Global Error by Replacing M with Local Functions for Telescope Key Mappings

### DIFF
--- a/docs/extras/coding/copilot-chat.md
+++ b/docs/extras/coding/copilot-chat.md
@@ -118,9 +118,25 @@ end
       mode = { "n", "v" },
     },
     -- Show help actions with telescope
-    { "<leader>ad", M.pick("help"), desc = "Diagnostic Help (CopilotChat)", mode = { "n", "v" } },
+    {
+      "<leader>ad",
+      function()
+        local actions = require("CopilotChat.actions")
+        require("CopilotChat.integrations.telescope").pick(actions.help_actions())
+      end,
+      desc = "Diagnostic Help (CopilotChat)",
+      mode = { "n", "v" },
+    },
     -- Show prompts actions with telescope
-    { "<leader>ap", M.pick("prompt"), desc = "Prompt Actions (CopilotChat)", mode = { "n", "v" } },
+    {
+      "<leader>ap",
+      function()
+        local actions = require("CopilotChat.actions")
+        require("CopilotChat.integrations.telescope").pick(actions.prompt_actions())
+      end,
+      desc = "Prompt Actions (CopilotChat)",
+      mode = { "n", "v" },
+    },
   },
   config = function(_, opts)
     local chat = require("CopilotChat")


### PR DESCRIPTION
This merge request addresses an issue where users encounter an Undefined global M error when using the full-spec configuration with copy/paste. The error arises from certain key mappings that rely on an undefined global variable M.

Issue:
When users copy and paste the full-spec configuration, they receive an Undefined global M error. This issue is related to the configuration of telescope key bindings in the Lua code.

Problematic Code:
```
-- Show help actions with telescope
{ "<leader>ad", M.pick("help"), desc = "Diagnostic Help (CopilotChat)", mode = { "n", "v" } },
-- Show prompts actions with telescope
{ "<leader>ap", M.pick("prompt"), desc = "Prompt Actions (CopilotChat)", mode = { "n", "v" } },
```
In the above code, M is expected to be a global variable that provides a pick method for key bindings. However, when users attempt to use this configuration, they encounter errors because M is not defined.
Fix:
The fix ensures that the key mappings correctly utilise local functions to retrieve actions and interact with telescope, resolving the Undefined global M error. Users can now successfully use these mappings without encountering undefined variable issues.