### PR TITLE
Add wget to package list for Docker.

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -89,7 +89,7 @@ with [PowerShell](https://github.com/PowerShell/PowerShell)
 
 ```sh
 docker run -w /root -it --rm alpine:edge sh -uelic '
-  apk add git lazygit neovim ripgrep alpine-sdk --update
+  apk add git lazygit neovim ripgrep alpine-sdk wget --update
   git clone https://github.com/LazyVim/starter ~/.config/nvim
   cd ~/.config/nvim
   nvim


### PR DESCRIPTION
Mason fails to retrieve the registry with the default busybox wget. Adding the wget package fixes this.