### PR TITLE
doc(tex): use `init` instead of `config` for vimtex

### DIFF
--- a/docs/extras/lang/tex.md
+++ b/docs/extras/lang/tex.md
@@ -100,7 +100,7 @@ opts = {}
 {
   "lervag/vimtex",
   lazy = false, -- lazy-loading will disable inverse search
-  config = function()
+  init = function()
     vim.g.vimtex_mappings_disable = { ["n"] = { "K" } } -- disable `K` as it conflicts with LSP hover
     vim.g.vimtex_quickfix_method = vim.fn.executable("pplatex") == 1 and "pplatex" or "latexlog"
   end,


### PR DESCRIPTION
VimTeX assumes all user options are defined _before_ it is initialized. With the `config` function, for some reason, this is unfortunately not true. I therefore strongly recommend that users use the `init` function. It should have a negligable impact on performance and avoids the race condition problem.