### PR TITLE
docs(keymaps): improve example of keymap overriding

### DIFF
--- a/docs/configuration/keymaps.md
+++ b/docs/configuration/keymaps.md
@@ -33,7 +33,7 @@ Lazyutils provides a `keys` LSP option for this purpose.
   "neovim/nvim-lspconfig",
   opts = {
     servers = {
-      tsserver = {
+      vtsls = {
         keys = {
           { "<leader>co", "<cmd>TypescriptOrganizeImports<CR>", desc = "Organize Imports" },
           { "<leader>cR", "<cmd>TypescriptRenameFile<CR>", desc = "Rename File" },


### PR DESCRIPTION
`tsserver` isn't used in LazyVim anymore. While this is just an example, it might be more helpful to provide users with something that they can copy-paste and expect to work.