### PR TITLE
docs: typo

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -21,7 +21,7 @@ For more information, see [configuring plugins](/configuration/plugins).
 │       ├── spec1.lua
 │       ├── **
 │       └── spec2.lua
-└── init.toml
+└── init.lua
 ```
 
 ## Icons & Colorscheme


### PR DESCRIPTION
Same typo as the one fixed in https://github.com/LazyVim/lazyvim.github.io/commit/cc5ced70b2277271222b8c2b8b60b359041d9da0.

