### PR TITLE
docs(installation): update docker instructions

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -89,7 +89,7 @@ with [PowerShell](https://github.com/PowerShell/PowerShell)
 
 ```sh
 docker run -w /root -it --rm alpine:edge sh -uelic '
-  apk add git lazygit neovim ripgrep alpine-sdk --update
+  apk add git lazygit fzf curl neovim ripgrep alpine-sdk --update
   git clone https://github.com/LazyVim/starter ~/.config/nvim
   cd ~/.config/nvim
   nvim


### PR DESCRIPTION
fzf and curl are new dependencies with LazyVim 14.0. This update compliments LazyVim/LazyVim#5020