### PR TITLE
Update intro.md to newer fzf minimum version

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -31,7 +31,7 @@ to make it easy to customize and extend your config.
 - a **C** compiler for `nvim-treesitter`. See [here](https://github.com/nvim-treesitter/nvim-treesitter#requirements)
 - **curl** for [blink.cmp](https://github.com/Saghen/blink.cmp) **(completion engine)**
 - for [fzf-lua](https://github.com/ibhagwan/fzf-lua) **_(optional)_**
-  - **fzf**: [fzf](https://github.com/junegunn/fzf) **(v0.25.1 or greater)**
+  - **fzf**: [fzf](https://github.com/junegunn/fzf) **(v0.36.0 or greater)**
   - **live grep**: [ripgrep](https://github.com/BurntSushi/ripgrep)
   - **find files**: [fd](https://github.com/sharkdp/fd)
 - a terminal that support true color and _undercurl_:


### PR DESCRIPTION
The option no scrollbar was added in fzf version 0.36.0 and it is used by lazyvim [here](https://github.com/LazyVim/LazyVim/blob/28d3ee49709978eb350e5c6bfe1f2ce36138c1d3/lua/lazyvim/plugins/extras/editor/fzf.lua#L93).

A lazyvim user reported this as an [issue](https://github.com/LazyVim/LazyVim/issues/5151) and was told to update, I think it is important to also update the docs :)

Related: https://github.com/LazyVim/LazyVim/pull/5177 -- I think this might resolve this in a better way, but not positive

I manually downloaded fzf version 0.36.0 and no longer faced the error which came up when using `apt` to install.