### PR TITLE
[doc]: Update supertab recipe for blink-cmp

### DIFF
--- a/docs/configuration/recipes.md
+++ b/docs/configuration/recipes.md
@@ -27,45 +27,19 @@ Use `<tab>` for completion and snippets (supertab).
 
 ```lua
 {
-  "hrsh7th/nvim-cmp",
-  ---@param opts cmp.ConfigSchema
-  opts = function(_, opts)
-    local has_words_before = function()
-      unpack = unpack or table.unpack
-      local line, col = unpack(vim.api.nvim_win_get_cursor(0))
-      return col ~= 0 and vim.api.nvim_buf_get_lines(0, line - 1, line, true)[1]:sub(col, col):match("%s") == nil
-    end
-
-    local cmp = require("cmp")
-
-    opts.mapping = vim.tbl_extend("force", opts.mapping, {
-      ["<Tab>"] = cmp.mapping(function(fallback)
-        if cmp.visible() then
-          -- You could replace select_next_item() with confirm({ select = true }) to get VS Code autocompletion behavior
-          cmp.select_next_item()
-        elseif vim.snippet.active({ direction = 1 }) then
-          vim.schedule(function()
-            vim.snippet.jump(1)
-          end)
-        elseif has_words_before() then
-          cmp.complete()
-        else
-          fallback()
-        end
-      end, { "i", "s" }),
-      ["<S-Tab>"] = cmp.mapping(function(fallback)
-        if cmp.visible() then
-          cmp.select_prev_item()
-        elseif vim.snippet.active({ direction = -1 }) then
-          vim.schedule(function()
-            vim.snippet.jump(-1)
-          end)
-        else
-          fallback()
-        end
-      end, { "i", "s" }),
-    })
-  end,
+  "saghen/blink.cmp",
+  opts = {
+    keymap = {
+      preset = "enter",
+      ["<Tab>"] = { "select_next", "fallback" },
+      ["<S-Tab>"] = { "select_prev", "fallback" },
+    },
+    completion = {
+      list = {
+        selection = "auto_insert",
+      },
+    },
+  },
 }
 ```
 


### PR DESCRIPTION
update supertab recipe to follow previous cmp engine after migrating to blink-cmp