### PR TITLE
docs: add fzf-lua guidance in the tokyonight transparency recipe

### DIFF
--- a/docs/configuration/recipes.md
+++ b/docs/configuration/recipes.md
@@ -102,6 +102,19 @@ Use `<tab>` for completion and snippets (supertab).
   },
 }
 ```
+And, optionally, make the fzf-lua file picker transparent as well:
+```lua
+{
+  "ibhagwan/fzf-lua",
+  opts = {
+    fzf_colors = {
+      true,
+      bg = "-1",
+      gutter = "-1",
+    },
+  },
+}
+```
 
 ## Fix clangd offset encoding
 


### PR DESCRIPTION
With the change to fzf-lua, provide instructions on how to make the fzf-lua file picker transparent as well. See https://github.com/LazyVim/LazyVim/discussions/5239 discussion for context.