### PR TITLE
Update the Supertab recipe in recipes.md with a blink.cmp snippet

### DIFF
--- a/docs/configuration/recipes.md
+++ b/docs/configuration/recipes.md
@@ -26,6 +26,49 @@ override nvim-cmp and add cmp-emoji
 Use `<tab>` for completion and snippets (supertab).
 
 ```lua
+return {
+  "saghen/blink.cmp",
+  -- optional: provides snippets for the snippet source
+  dependencies = "rafamadriz/friendly-snippets",
+
+  -- use a release tag to download pre-built binaries
+  version = "*",
+  -- AND/OR build from source, requires nightly: https://rust-lang.github.io/rustup/concepts/channels.html#working-with-nightly-rust
+  -- build = 'cargo build --release',
+  -- If you use nix, you can build from source using latest nightly rust with:
+  -- build = 'nix run .#build-plugin',
+
+  ---@module 'blink.cmp'
+  ---@type blink.cmp.Config
+  opts = {
+    -- 'default' for mappings similar to built-in completion
+    -- 'super-tab' for mappings similar to vscode (tab to accept, arrow keys to navigate)
+    -- 'enter' for mappings similar to 'super-tab' but with 'enter' to accept
+    -- See the full "keymap" documentation for information on defining your own keymap.
+    keymap = { preset = "super-tab" },
+
+    appearance = {
+      -- Sets the fallback highlight groups to nvim-cmp's highlight groups
+      -- Useful for when your theme doesn't support blink.cmp
+      -- Will be removed in a future release
+      use_nvim_cmp_as_default = true,
+      -- Set to 'mono' for 'Nerd Font Mono' or 'normal' for 'Nerd Font'
+      -- Adjusts spacing to ensure icons are aligned
+      nerd_font_variant = "mono",
+    },
+
+    -- Default list of enabled providers defined so that you can extend it
+    -- elsewhere in your config, without redefining it, due to `opts_extend`
+    sources = {
+      default = { "lsp", "path", "snippets", "buffer" },
+    },
+  },
+  opts_extend = { "sources.default" },
+}
+```
+
+Or, if you prefer `nvim-cmp`,
+```lua
 {
   "hrsh7th/nvim-cmp",
   ---@param opts cmp.ConfigSchema


### PR DESCRIPTION
As evidenced in #250, new users often don't know how to switch to supertab mode for completions. Since the blink extra is now included by default, the recipe currently present in the docs is a little misleading. This PR just adds in the snippet from Blink's [documentation](https://cmp.saghen.dev/installation) (thanks @noprobelm for mentioning this in the tab completion issue discussion) 