### PR TITLE
docs(recipes): Add recipe for enabling supertab behavior in blink.cmp

### DIFF
--- a/docs/configuration/recipes.md
+++ b/docs/configuration/recipes.md
@@ -25,6 +25,23 @@ override nvim-cmp and add cmp-emoji
 
 Use `<tab>` for completion and snippets (supertab).
 
+### blink.cmp
+
+```lua
+{
+  "Saghen/blink.cmp",
+  opts = {
+   keymap = {
+    preset = "enter",
+    ["<Tab>"] = { "select_next", "fallback" },
+    ["<S-Tab>"] = { "select_prev", "fallback" },
+   },
+  },
+ }
+```
+
+### nvim-cmp
+
 ```lua
 {
   "hrsh7th/nvim-cmp",

--- a/lua/recipes.lua
+++ b/lua/recipes.lua
@@ -11,7 +11,7 @@ return {
     end,
   },
 
-  -- ## Supertab
+  -- ## Supertab for nvim-cmp
   --
   -- Use `<tab>` for completion and snippets (supertab).
   {
@@ -54,6 +54,20 @@ return {
         end, { "i", "s" }),
       })
     end,
+  },
+
+  -- ## Supertab for blink.cmp
+  --
+  -- Use `<tab>` for completion and snippets (supertab).
+  {
+    "Saghen/blink.cmp",
+    opts = {
+      keymap = {
+        preset = "enter",
+        ["<Tab>"] = { "select_next", "fallback" },
+        ["<S-Tab>"] = { "select_prev", "fallback" },
+      },
+    },
   },
 
   -- ## Change surround mappings


### PR DESCRIPTION
This recipe sets up blink.cmp's bindings such that <Tab> will navigate down a list of completions, and <S-Tab> will navigate up that list. Enter will submit the selected completion and drop the user into the completion's parameter(s) or directly after the inserted text, whichever applies to that completion.

For reference, I had to dig for close to an hour to figure out how to do this.

The following reddit thread is a collection of similar frustrations, as well as multiple outdated ways to achieve this:
https://www.reddit.com/r/neovim/comments/1hfotru/nvimcmp_super_tab_in_blink/

An incomplete solution is here:
https://github.com/LazyVim/LazyVim/discussions/250#discussioncomment-12461707

But the preset must be set to "enter", as noted here: https://github.com/Saghen/blink.cmp/discussions/576#discussioncomment-11599108

I plainly cannot find where this is documented within blink.cmp's docs.