### PR TITLE
update link to plugin spec

### DIFF
--- a/docs/configuration/plugins.md
+++ b/docs/configuration/plugins.md
@@ -8,7 +8,7 @@ Configuring **LazyVim** plugins is exactly the same as using **lazy.nvim** to bu
 a config from scratch.
 
 For the full plugin spec documentation please check the **lazy.nvim**
-[readme](https://github.com/folke/lazy.nvim).
+[plugin spec](https://lazy.folke.io/spec).
 
 Refer to the **plugins** section in the sidebar for configuring
 included plugins.


### PR DESCRIPTION
The readme.md of the lazy.vim repo doesn't really provide any useful information about the plugin spec or where to find it..