### PR TITLE
Link to GitUI's website

### DIFF
--- a/docs/extras/util/gitui.md
+++ b/docs/extras/util/gitui.md
@@ -19,7 +19,7 @@ import TabItem from '@theme/TabItem';
 
 ## [mason.nvim](https://github.com/mason-org/mason.nvim)
 
- Ensure GitUI tool is installed
+ Ensure [GitUI tool](https://github.com/gitui-org/gitui) is installed
 
 
 <Tabs>


### PR DESCRIPTION
For those unfamiliar with GitUI, it is helpful to link to its website. This adds a link in the gitui page.