### PR TITLE
Add MacOS Terminal.app to terminal requirements.

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -38,6 +38,7 @@ to make it easy to customize and extend your config.
   - [kitty](https://github.com/kovidgoyal/kitty) **_(Linux & Macos)_**
   - [wezterm](https://github.com/wez/wezterm) **_(Linux, Macos & Windows)_**
   - [alacritty](https://github.com/alacritty/alacritty) **_(Linux, Macos & Windows)_**
+  - Terminal.app (Macos 26+)
   - [iterm2](https://iterm2.com/) **_(Macos)_**
 
 ## 🎓 Learn


### PR DESCRIPTION
As of MacOS 26, the default Terminal.app supports truecolor and nerdfonts.