### PR TITLE
Fix a readability typo in configuration (general) documentation

### DIFF
--- a/docs/configuration/general.md
+++ b/docs/configuration/general.md
@@ -25,7 +25,7 @@ so you don't need to require those files manually.
 ```
 
 :::danger
-Do not `require` `autocmds`, `keymaps`, `lazy` or `options` under `lua/config/` or `lazyvim.config` manually.
+Do not require `autocmds`, `keymaps`, `lazy` or `options` under `lua/config/` or `lazyvim.config` manually.
 **LazyVim** will load those files automatically.
 :::
 


### PR DESCRIPTION
Small PR to fix Incorrect highlighting of the word 'require' in docs/configuration/general.md

<img width="1023" height="472" alt="image" src="https://github.com/user-attachments/assets/d810fa54-ab40-4bc6-acc3-ac86e899bbab" />
The relevant text is In the red warning box.

At least for me, my brain logically bucketed `require` as a configuration file similarly to all the other highlighted words in the box. So I thought it may be better if it wasn't highlighted.