### PR TITLE
Suggest a shallow clone since we'll remove .git anyway

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -29,7 +29,7 @@ Install the [LazyVim Starter](https://github.com/LazyVim/starter)
 - Clone the starter
 
   ```sh
-  git clone https://github.com/LazyVim/starter ~/.config/nvim
+  git clone --depth=1 https://github.com/LazyVim/starter ~/.config/nvim
   ```
 
 - Remove the `.git` folder, so you can add it to your own repo later


### PR DESCRIPTION
The documentation currently proposes doing a full git clone as a means of installing, and then throwing away the `.git` directory.  This is wasteful, as clone by default will retrieve the complete commit history.

If we pass `--depth=1`, it will only retrieve the head commit.  This saves bandwidth, resources, and time; on top of being more polite.