### PR TITLE
fix inconsistency

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -26,7 +26,7 @@ to make it easy to customize and extend your config.
 
 - Neovim >= **0.11.2** (needs to be built with **LuaJIT**)
 - Git >= **2.19.0** (for partial clones support)
-- a [Nerd Font](https://www.nerdfonts.com/)(v3.0 or greater) **_(optional, but needed to display some icons)_**
+- a [Nerd Font](https://www.nerdfonts.com/) (v3.0 or greater) **_(optional, but needed to display some icons)_**
 - [lazygit](https://github.com/jesseduffield/lazygit) **_(optional)_**
 - **tree-sitter-cli** and a **C** compiler for `nvim-treesitter`. See [here](https://github.com/nvim-treesitter/nvim-treesitter/tree/main?tab=readme-ov-file#requirements)
 - **curl** for [blink.cmp](https://github.com/Saghen/blink.cmp) **(completion engine)**


### PR DESCRIPTION
added a space between 'a Nerd Font' and '(v3.0 or greater)' because its a better practice and to keep the page consistent as all the other parentheses are after a space