### PR TITLE
docs: clarify prettier snippet context

### DIFF
--- a/docs/extras/formatting/prettier.md
+++ b/docs/extras/formatting/prettier.md
@@ -81,6 +81,10 @@ end
 
 </TabItem>
 
+:::info
+The snippets below rely on values defined in LazyVim's Prettier extra implementation
+(`supported`, `M.has_parser`, `M.has_config`), so they are shown for reference only.
+:::
 
 <TabItem value="code" label="Full Spec">
 


### PR DESCRIPTION
## Summary

- Clarify that the Prettier snippet in `docs/extras/formatting/prettier.md` references
  module-local values from the LazyVim extra implementation.

## Why

- The snippet uses `supported` and `M.*`, which are not standalone example values.
- The note helps readers understand the snippet context without changing the code example.
